### PR TITLE
Stop and mask the ntpd instead of remove it

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -2,5 +2,10 @@
 - name: Install the required packages in Redhat derivatives
   yum: name=chrony state={{ chrony_pkg_state }}
 
-- name: Remove NTP if installed in Redhat
-  yum: name=ntp state=absent
+- name: Check if ntpd service exists
+  stat: path="/usr/lib/systemd/system/ntpd.service"
+  register: ntpd_service_status
+
+- name: Stop and mask ntpd service
+  systemd: name=ntpd state=stopped masked=yes
+  when: ntpd_service_status.stat.exists == True


### PR DESCRIPTION
In some cases when the NTP is dependent on other packages we have
a situation that we have to remove these packages in order to remove
the NTP which is not the main idea of this project.
thus IMHO it will be better to stop and disable the NTP instead of
remove it.

Note:
The block feature introduced in ansible 2.0