### PR TITLE
Package state 'present' instead of 'installed'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-chrony_pkg_state: 'installed'
+chrony_pkg_state: 'present'
 chrony_service_state: 'started'
 chrony_service_enabled: 'yes'
 


### PR DESCRIPTION
With ansible 2.6.1, I got the message:

Deprecation warning:
State 'installed' is deprecated. Using state 'present' instead. This feature will be removed in version 2.9.