### PR TITLE
Add EL 8 as supported OS version for usage with Centos / RHEL

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
     - name: Debian
       versions:
         - jessie


### PR DESCRIPTION
As Centos / RHEL 8 still use chrony it would be nice add support to this role. From what we seen internally there should be no more work involved.